### PR TITLE
「コンピュータとプログラミング」と「システムプログラム序論」の読み替え

### DIFF
--- a/coins19.json
+++ b/coins19.json
@@ -140,7 +140,7 @@
                                         "min_certificated_credit_num": 3,
                                         "leaf": {
                                             "regexp_number": "",
-                                            "regexp_name": "^コンピュータとプログラミング$"
+                                            "regexp_name": "^(コンピュータとプログラミング|システムプログラミング序論)$"
                                         }
                                     },
                                     "ＤＳＡ": {


### PR DESCRIPTION
coins19 においては、「システムプログラミング序論」（GB11954、2019年開設）の単位が「コンピュータとプログラミング」（GB11964、2020年開設）に読み替えできるとされているため、これに対応したルールを追加しました。