### PR TITLE
Reactのバージョンを18にする

### DIFF
--- a/.github/workflows/build-on-merge.yml
+++ b/.github/workflows/build-on-merge.yml
@@ -1,0 +1,54 @@
+name: build on merge
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./react-visualizer
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - uses: actions/cache@v4
+        id: node_modules_cache_id
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+      - if: ${{ steps.node_modules_cache_id.outputs.cache-hit != 'true' }}
+        run: npm install
+      - name: Build
+        run: |
+          npm run build
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: ./react-visualizer/build
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/build-on-pr.yml
+++ b/.github/workflows/build-on-pr.yml
@@ -1,17 +1,5 @@
-name: build
-on:
-  push:
-    branches:
-      - main
-
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-concurrency:
-  group: "pages"
-  cancel-in-progress: false
+name: build on pr
+on: pull_request
 
 jobs:
   build:
@@ -38,17 +26,4 @@ jobs:
       - name: Build
         run: |
           npm run build
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
-        with:
-          path: ./react-visualizer/build
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v2
+      

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,12 +21,12 @@ jobs:
         working-directory: ./react-visualizer
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 16
-      - uses: actions/cache@v3
+          node-version: 20
+      - uses: actions/cache@v4
         id: node_modules_cache_id
         env:
           cache-name: cache-node-modules

--- a/.gitignore
+++ b/.gitignore
@@ -129,7 +129,4 @@ dmypy.json
 .pyre/
 
 
-node_modules/
-
-
 SIRS*

--- a/react-visualizer/.gitignore
+++ b/react-visualizer/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+build/

--- a/react-visualizer/package-lock.json
+++ b/react-visualizer/package-lock.json
@@ -4468,7 +4468,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001439",
+            "version": "1.0.30001607",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001607.tgz",
+            "integrity": "sha512-WcvhVRjXLKFB/kmOFVwELtMxyhq3iM/MvmXcyCe2PNf166c39mptscOc/45TTS96n2gpNV2z7+NakArTWZCQ3w==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -4477,9 +4479,12 @@
                 {
                     "type": "tidelift",
                     "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
                 }
-            ],
-            "license": "CC-BY-4.0"
+            ]
         },
         "node_modules/case-sensitive-paths-webpack-plugin": {
             "version": "2.4.0",

--- a/react-visualizer/package-lock.json
+++ b/react-visualizer/package-lock.json
@@ -8,19 +8,19 @@
             "name": "g-checker-from-itf",
             "version": "0.1.0",
             "dependencies": {
-                "bootstrap": "^5.1.3",
-                "react": "^17.0.2",
-                "react-bootstrap": "^2.1.2",
-                "react-dom": "^17.0.2",
-                "react-scripts": "5.0.0",
-                "react-select": "^5.2.2",
-                "react-table": "^7.7.0",
-                "web-vitals": "^2.1.4"
+                "bootstrap": "^5.3.3",
+                "react": "^18.2.0",
+                "react-bootstrap": "^2.10.2",
+                "react-dom": "^18.2.0",
+                "react-scripts": "5.0.1",
+                "react-select": "^5.8.0",
+                "react-table": "^7.8.0",
+                "web-vitals": "^3.5.2"
             },
             "devDependencies": {
-                "gh-pages": "^3.2.3",
-                "prettier": "^2.6.2",
-                "typescript": "^4.6.3"
+                "gh-pages": "^6.1.1",
+                "prettier": "^3.2.5",
+                "typescript": "^5.4.4"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -1672,10 +1672,11 @@
             }
         },
         "node_modules/@babel/runtime": {
-            "version": "7.20.6",
-            "license": "MIT",
+            "version": "7.24.4",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.4.tgz",
+            "integrity": "sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==",
             "dependencies": {
-                "regenerator-runtime": "^0.13.11"
+                "regenerator-runtime": "^0.14.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1691,6 +1692,11 @@
             "engines": {
                 "node": ">=6.9.0"
             }
+        },
+        "node_modules/@babel/runtime/node_modules/regenerator-runtime": {
+            "version": "0.14.1",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
         },
         "node_modules/@babel/template": {
             "version": "7.18.10",
@@ -2665,50 +2671,65 @@
             }
         },
         "node_modules/@popperjs/core": {
-            "version": "2.11.6",
-            "license": "MIT",
+            "version": "2.11.8",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+            "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/popperjs"
             }
         },
         "node_modules/@react-aria/ssr": {
-            "version": "3.4.0",
-            "license": "Apache-2.0",
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.2.tgz",
+            "integrity": "sha512-0gKkgDYdnq1w+ey8KzG9l+H5Z821qh9vVjztk55rUg71vTk/Eaebeir+WtzcLLwTjw3m/asIjx8Y59y1lJZhBw==",
             "dependencies": {
-                "@babel/runtime": "^7.6.2"
+                "@swc/helpers": "^0.5.0"
+            },
+            "engines": {
+                "node": ">= 12"
             },
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
             }
         },
         "node_modules/@restart/hooks": {
-            "version": "0.4.7",
-            "license": "MIT",
+            "version": "0.4.16",
+            "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.4.16.tgz",
+            "integrity": "sha512-f7aCv7c+nU/3mF7NWLtVVr0Ra80RqsO89hO72r+Y/nvQr5+q0UFGkocElTH6MJApvReVh6JHUFYn2cw1WdHF3w==",
             "dependencies": {
-                "dequal": "^2.0.2"
+                "dequal": "^2.0.3"
             },
             "peerDependencies": {
                 "react": ">=16.8.0"
             }
         },
         "node_modules/@restart/ui": {
-            "version": "1.4.1",
-            "license": "MIT",
+            "version": "1.6.8",
+            "resolved": "https://registry.npmjs.org/@restart/ui/-/ui-1.6.8.tgz",
+            "integrity": "sha512-6ndCv3oZ7r9vuP1Ok9KH55TM1/UkdBnP/fSraW0DFDMbPMzWKhVKeFAIEUCRCSdzayjZDcFYK6xbMlipN9dmMA==",
             "dependencies": {
-                "@babel/runtime": "^7.18.3",
-                "@popperjs/core": "^2.11.5",
-                "@react-aria/ssr": "^3.2.0",
-                "@restart/hooks": "^0.4.7",
+                "@babel/runtime": "^7.21.0",
+                "@popperjs/core": "^2.11.6",
+                "@react-aria/ssr": "^3.5.0",
+                "@restart/hooks": "^0.4.9",
                 "@types/warning": "^3.0.0",
-                "dequal": "^2.0.2",
+                "dequal": "^2.0.3",
                 "dom-helpers": "^5.2.0",
-                "uncontrollable": "^7.2.1",
+                "uncontrollable": "^8.0.1",
                 "warning": "^4.0.3"
             },
             "peerDependencies": {
                 "react": ">=16.14.0",
                 "react-dom": ">=16.14.0"
+            }
+        },
+        "node_modules/@restart/ui/node_modules/uncontrollable": {
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-8.0.4.tgz",
+            "integrity": "sha512-ulRWYWHvscPFc0QQXvyJjY6LIXU56f0h8pQFvhxiKk5V1fcI8gp9Ht9leVAhrVjzqMw0BgjspBINx9r6oyJUvQ==",
+            "peerDependencies": {
+                "react": ">=16.14.0"
             }
         },
         "node_modules/@rollup/plugin-babel": {
@@ -3005,6 +3026,14 @@
                 "url": "https://github.com/sponsors/gregberge"
             }
         },
+        "node_modules/@swc/helpers": {
+            "version": "0.5.8",
+            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.8.tgz",
+            "integrity": "sha512-lruDGw3pnfM3wmZHeW7JuhkGQaJjPyiKjxeGhdmfoOT53Ic9qb5JLDNaK2HUdl1zLDeX28H221UvKjfdvSLVMg==",
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
         "node_modules/@tootallnate/once": {
             "version": "1.1.2",
             "license": "MIT",
@@ -3208,8 +3237,9 @@
             }
         },
         "node_modules/@types/react-transition-group": {
-            "version": "4.4.5",
-            "license": "MIT",
+            "version": "4.4.10",
+            "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.10.tgz",
+            "integrity": "sha512-hT/+s0VQs2ojCX823m60m5f0sL5idt9SO6Tj6Dg+rdphGPIeJbJ6CxvBYkgkGKrYeDjvIpKTR38UzmtHJOGW3Q==",
             "dependencies": {
                 "@types/react": "*"
             }
@@ -3264,8 +3294,9 @@
             "license": "MIT"
         },
         "node_modules/@types/warning": {
-            "version": "3.0.0",
-            "license": "MIT"
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.3.tgz",
+            "integrity": "sha512-D1XC7WK8K+zZEveUPY+cf4+kgauk8N4eHr/XIHXGlGYkHLud6hK9lYfZk1ry1TNh798cZUCgb6MqGEG8DkJt6Q=="
         },
         "node_modules/@types/ws": {
             "version": "8.5.3",
@@ -3948,12 +3979,9 @@
             "license": "ISC"
         },
         "node_modules/async": {
-            "version": "2.6.4",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "lodash": "^4.17.14"
-            }
+            "version": "3.2.5",
+            "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
+            "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
         },
         "node_modules/asynckit": {
             "version": "0.4.0",
@@ -4293,7 +4321,9 @@
             "license": "ISC"
         },
         "node_modules/bootstrap": {
-            "version": "5.2.3",
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.3.tgz",
+            "integrity": "sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==",
             "funding": [
                 {
                     "type": "github",
@@ -4304,9 +4334,8 @@
                     "url": "https://opencollective.com/bootstrap"
                 }
             ],
-            "license": "MIT",
             "peerDependencies": {
-                "@popperjs/core": "^2.11.6"
+                "@popperjs/core": "^2.11.8"
             }
         },
         "node_modules/brace-expansion": {
@@ -5231,7 +5260,8 @@
         },
         "node_modules/dequal": {
             "version": "2.0.3",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+            "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
             "engines": {
                 "node": ">=6"
             }
@@ -5469,9 +5499,10 @@
             "license": "ISC"
         },
         "node_modules/email-addresses": {
-            "version": "3.1.0",
-            "dev": true,
-            "license": "MIT"
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-5.0.0.tgz",
+            "integrity": "sha512-4OIPYlA6JXqtVn8zpHpGiI7vE6EQOAg16aGnDMIAlZVinnoZ8208tW1hAbjWydgN/4PLTT9q+O1K6AH/vALJGw==",
+            "dev": true
         },
         "node_modules/emittery": {
             "version": "0.8.1",
@@ -6690,6 +6721,19 @@
             "version": "1.0.0",
             "license": "ISC"
         },
+        "node_modules/fsevents": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "hasInstallScript": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
         "node_modules/function-bind": {
             "version": "1.1.1",
             "license": "MIT"
@@ -6779,16 +6823,17 @@
             }
         },
         "node_modules/gh-pages": {
-            "version": "3.2.3",
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-6.1.1.tgz",
+            "integrity": "sha512-upnohfjBwN5hBP9w2dPE7HO5JJTHzSGMV1JrLrHvNuqmjoYHg6TBrCcnEoorjG/e0ejbuvnwyKMdTyM40PEByw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "async": "^2.6.1",
-                "commander": "^2.18.0",
-                "email-addresses": "^3.0.1",
+                "async": "^3.2.4",
+                "commander": "^11.0.0",
+                "email-addresses": "^5.0.0",
                 "filenamify": "^4.3.0",
                 "find-cache-dir": "^3.3.1",
-                "fs-extra": "^8.1.0",
+                "fs-extra": "^11.1.1",
                 "globby": "^6.1.0"
             },
             "bin": {
@@ -6810,17 +6855,27 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/gh-pages/node_modules/fs-extra": {
-            "version": "8.1.0",
+        "node_modules/gh-pages/node_modules/commander": {
+            "version": "11.1.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+            "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
             "dev": true,
-            "license": "MIT",
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/gh-pages/node_modules/fs-extra": {
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+            "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+            "dev": true,
             "dependencies": {
                 "graceful-fs": "^4.2.0",
-                "jsonfile": "^4.0.0",
-                "universalify": "^0.1.0"
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
             },
             "engines": {
-                "node": ">=6 <7 || >=8"
+                "node": ">=14.14"
             }
         },
         "node_modules/gh-pages/node_modules/globby": {
@@ -6836,22 +6891,6 @@
             },
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/gh-pages/node_modules/jsonfile": {
-            "version": "4.0.0",
-            "dev": true,
-            "license": "MIT",
-            "optionalDependencies": {
-                "graceful-fs": "^4.1.6"
-            }
-        },
-        "node_modules/gh-pages/node_modules/universalify": {
-            "version": "0.1.2",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 4.0.0"
             }
         },
         "node_modules/glob": {
@@ -7752,10 +7791,6 @@
             "engines": {
                 "node": ">=10"
             }
-        },
-        "node_modules/jake/node_modules/async": {
-            "version": "3.2.4",
-            "license": "MIT"
         },
         "node_modules/jest": {
             "version": "27.5.1",
@@ -10678,14 +10713,15 @@
             }
         },
         "node_modules/prettier": {
-            "version": "2.8.1",
+            "version": "3.2.5",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+            "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
             "dev": true,
-            "license": "MIT",
             "bin": {
-                "prettier": "bin-prettier.js"
+                "prettier": "bin/prettier.cjs"
             },
             "engines": {
-                "node": ">=10.13.0"
+                "node": ">=14"
             },
             "funding": {
                 "url": "https://github.com/prettier/prettier?sponsor=1"
@@ -10894,11 +10930,11 @@
             }
         },
         "node_modules/react": {
-            "version": "17.0.2",
-            "license": "MIT",
+            "version": "18.2.0",
+            "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+            "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
             "dependencies": {
-                "loose-envify": "^1.1.0",
-                "object-assign": "^4.1.1"
+                "loose-envify": "^1.1.0"
             },
             "engines": {
                 "node": ">=0.10.0"
@@ -10920,19 +10956,20 @@
             }
         },
         "node_modules/react-bootstrap": {
-            "version": "2.7.0",
-            "license": "MIT",
+            "version": "2.10.2",
+            "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.10.2.tgz",
+            "integrity": "sha512-UvB7mRqQjivdZNxJNEA2yOQRB7L9N43nBnKc33K47+cH90/ujmnMwatTCwQLu83gLhrzAl8fsa6Lqig/KLghaA==",
             "dependencies": {
-                "@babel/runtime": "^7.17.2",
-                "@restart/hooks": "^0.4.6",
-                "@restart/ui": "^1.4.1",
-                "@types/react-transition-group": "^4.4.4",
-                "classnames": "^2.3.1",
+                "@babel/runtime": "^7.22.5",
+                "@restart/hooks": "^0.4.9",
+                "@restart/ui": "^1.6.8",
+                "@types/react-transition-group": "^4.4.6",
+                "classnames": "^2.3.2",
                 "dom-helpers": "^5.2.1",
                 "invariant": "^2.2.4",
                 "prop-types": "^15.8.1",
                 "prop-types-extra": "^1.1.0",
-                "react-transition-group": "^4.4.2",
+                "react-transition-group": "^4.4.5",
                 "uncontrollable": "^7.2.1",
                 "warning": "^4.0.3"
             },
@@ -10998,15 +11035,15 @@
             }
         },
         "node_modules/react-dom": {
-            "version": "17.0.2",
-            "license": "MIT",
+            "version": "18.2.0",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+            "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
             "dependencies": {
                 "loose-envify": "^1.1.0",
-                "object-assign": "^4.1.1",
-                "scheduler": "^0.20.2"
+                "scheduler": "^0.23.0"
             },
             "peerDependencies": {
-                "react": "17.0.2"
+                "react": "^18.2.0"
             }
         },
         "node_modules/react-error-overlay": {
@@ -11029,8 +11066,9 @@
             }
         },
         "node_modules/react-scripts": {
-            "version": "5.0.0",
-            "license": "MIT",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-5.0.1.tgz",
+            "integrity": "sha512-8VAmEm/ZAwQzJ+GOMLbBsTdDKOpuZh7RPs0UymvBR2vRk4iZWCskjbFnxqjrzoIvlNNRZ3QJFx6/qDSi6zSnaQ==",
             "dependencies": {
                 "@babel/core": "^7.16.0",
                 "@pmmmwh/react-refresh-webpack-plugin": "^0.5.3",
@@ -11048,7 +11086,7 @@
                 "dotenv": "^10.0.0",
                 "dotenv-expand": "^5.1.0",
                 "eslint": "^8.3.0",
-                "eslint-config-react-app": "^7.0.0",
+                "eslint-config-react-app": "^7.0.1",
                 "eslint-webpack-plugin": "^3.1.1",
                 "file-loader": "^6.2.0",
                 "fs-extra": "^10.0.0",
@@ -11065,7 +11103,7 @@
                 "postcss-preset-env": "^7.0.1",
                 "prompts": "^2.4.2",
                 "react-app-polyfill": "^3.0.0",
-                "react-dev-utils": "^12.0.0",
+                "react-dev-utils": "^12.0.1",
                 "react-refresh": "^0.11.0",
                 "resolve": "^1.20.0",
                 "resolve-url-loader": "^4.0.0",
@@ -11125,8 +11163,9 @@
             }
         },
         "node_modules/react-select": {
-            "version": "5.7.0",
-            "license": "MIT",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.8.0.tgz",
+            "integrity": "sha512-TfjLDo58XrhP6VG5M/Mi56Us0Yt8X7xD6cDybC7yoRMUNm7BGO7qk8J0TLQOua/prb8vUOtsfnXZwfm30HGsAA==",
             "dependencies": {
                 "@babel/runtime": "^7.12.0",
                 "@emotion/cache": "^11.4.0",
@@ -11156,7 +11195,8 @@
         },
         "node_modules/react-transition-group": {
             "version": "4.4.5",
-            "license": "BSD-3-Clause",
+            "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+            "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
             "dependencies": {
                 "@babel/runtime": "^7.5.5",
                 "dom-helpers": "^5.0.1",
@@ -11599,11 +11639,11 @@
             }
         },
         "node_modules/scheduler": {
-            "version": "0.20.2",
-            "license": "MIT",
+            "version": "0.23.0",
+            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+            "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
             "dependencies": {
-                "loose-envify": "^1.1.0",
-                "object-assign": "^4.1.1"
+                "loose-envify": "^1.1.0"
             }
         },
         "node_modules/schema-utils": {
@@ -12699,14 +12739,15 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.9.4",
-            "license": "Apache-2.0",
+            "version": "5.4.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.4.tgz",
+            "integrity": "sha512-dGE2Vv8cpVvw28v8HCPqyb08EzbBURxDpuhJvTrusShUfGnhHBafDsLdS1EhhxyL6BJQE+2cT3dDPAv+MQ6oLw==",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
             },
             "engines": {
-                "node": ">=4.2.0"
+                "node": ">=14.17"
             }
         },
         "node_modules/unbox-primitive": {
@@ -12965,8 +13006,9 @@
             }
         },
         "node_modules/web-vitals": {
-            "version": "2.1.4",
-            "license": "Apache-2.0"
+            "version": "3.5.2",
+            "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.5.2.tgz",
+            "integrity": "sha512-c0rhqNcHXRkY/ogGDJQxZ9Im9D19hDihbzSQJrsioex+KnFgmMzBiy57Z1EjkhX/+OjyBpclDCzz2ITtjokFmg=="
         },
         "node_modules/webidl-conversions": {
             "version": "6.1.0",

--- a/react-visualizer/package-lock.json
+++ b/react-visualizer/package-lock.json
@@ -20,7 +20,7 @@
             "devDependencies": {
                 "gh-pages": "^6.1.1",
                 "prettier": "^3.2.5",
-                "typescript": "^5.4.4"
+                "typescript": "^4.6.3"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -12739,15 +12739,15 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.4.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.4.tgz",
-            "integrity": "sha512-dGE2Vv8cpVvw28v8HCPqyb08EzbBURxDpuhJvTrusShUfGnhHBafDsLdS1EhhxyL6BJQE+2cT3dDPAv+MQ6oLw==",
+            "version": "4.9.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
             },
             "engines": {
-                "node": ">=14.17"
+                "node": ">=4.2.0"
             }
         },
         "node_modules/unbox-primitive": {

--- a/react-visualizer/package-lock.json
+++ b/react-visualizer/package-lock.json
@@ -8,9 +8,6 @@
             "name": "g-checker-from-itf",
             "version": "0.1.0",
             "dependencies": {
-                "@testing-library/jest-dom": "^5.16.1",
-                "@testing-library/react": "^12.1.2",
-                "@testing-library/user-event": "^13.5.0",
                 "bootstrap": "^5.1.3",
                 "react": "^17.0.2",
                 "react-bootstrap": "^2.1.2",
@@ -25,10 +22,6 @@
                 "prettier": "^2.6.2",
                 "typescript": "^4.6.3"
             }
-        },
-        "node_modules/@adobe/css-tools": {
-            "version": "4.0.1",
-            "license": "MIT"
         },
         "node_modules/@ampproject/remapping": {
             "version": "2.2.0",
@@ -2352,23 +2345,6 @@
                 "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
             }
         },
-        "node_modules/@jest/expect-utils": {
-            "version": "29.3.1",
-            "license": "MIT",
-            "dependencies": {
-                "jest-get-type": "^29.2.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@jest/expect-utils/node_modules/jest-get-type": {
-            "version": "29.2.0",
-            "license": "MIT",
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
         "node_modules/@jest/fake-timers": {
             "version": "27.5.1",
             "license": "MIT",
@@ -3029,84 +3005,6 @@
                 "url": "https://github.com/sponsors/gregberge"
             }
         },
-        "node_modules/@testing-library/dom": {
-            "version": "8.19.0",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/code-frame": "^7.10.4",
-                "@babel/runtime": "^7.12.5",
-                "@types/aria-query": "^4.2.0",
-                "aria-query": "^5.0.0",
-                "chalk": "^4.1.0",
-                "dom-accessibility-api": "^0.5.9",
-                "lz-string": "^1.4.4",
-                "pretty-format": "^27.0.2"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@testing-library/jest-dom": {
-            "version": "5.16.5",
-            "license": "MIT",
-            "dependencies": {
-                "@adobe/css-tools": "^4.0.1",
-                "@babel/runtime": "^7.9.2",
-                "@types/testing-library__jest-dom": "^5.9.1",
-                "aria-query": "^5.0.0",
-                "chalk": "^3.0.0",
-                "css.escape": "^1.5.1",
-                "dom-accessibility-api": "^0.5.6",
-                "lodash": "^4.17.15",
-                "redent": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8",
-                "npm": ">=6",
-                "yarn": ">=1"
-            }
-        },
-        "node_modules/@testing-library/jest-dom/node_modules/chalk": {
-            "version": "3.0.0",
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@testing-library/react": {
-            "version": "12.1.5",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.12.5",
-                "@testing-library/dom": "^8.0.0",
-                "@types/react-dom": "<18.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "peerDependencies": {
-                "react": "<18.0.0",
-                "react-dom": "<18.0.0"
-            }
-        },
-        "node_modules/@testing-library/user-event": {
-            "version": "13.5.0",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.12.5"
-            },
-            "engines": {
-                "node": ">=10",
-                "npm": ">=6"
-            },
-            "peerDependencies": {
-                "@testing-library/dom": ">=7.21.4"
-            }
-        },
         "node_modules/@tootallnate/once": {
             "version": "1.1.2",
             "license": "MIT",
@@ -3120,10 +3018,6 @@
             "engines": {
                 "node": ">=10.13.0"
             }
-        },
-        "node_modules/@types/aria-query": {
-            "version": "4.2.2",
-            "license": "MIT"
         },
         "node_modules/@types/babel__core": {
             "version": "7.1.20",
@@ -3263,152 +3157,6 @@
                 "@types/istanbul-lib-report": "*"
             }
         },
-        "node_modules/@types/jest": {
-            "version": "29.2.4",
-            "license": "MIT",
-            "dependencies": {
-                "expect": "^29.0.0",
-                "pretty-format": "^29.0.0"
-            }
-        },
-        "node_modules/@types/jest/node_modules/@jest/schemas": {
-            "version": "29.0.0",
-            "license": "MIT",
-            "dependencies": {
-                "@sinclair/typebox": "^0.24.1"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@types/jest/node_modules/@jest/types": {
-            "version": "29.3.1",
-            "license": "MIT",
-            "dependencies": {
-                "@jest/schemas": "^29.0.0",
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "@types/istanbul-reports": "^3.0.0",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.8",
-                "chalk": "^4.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@types/jest/node_modules/ansi-styles": {
-            "version": "5.2.0",
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/@types/jest/node_modules/diff-sequences": {
-            "version": "29.3.1",
-            "license": "MIT",
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@types/jest/node_modules/expect": {
-            "version": "29.3.1",
-            "license": "MIT",
-            "dependencies": {
-                "@jest/expect-utils": "^29.3.1",
-                "jest-get-type": "^29.2.0",
-                "jest-matcher-utils": "^29.3.1",
-                "jest-message-util": "^29.3.1",
-                "jest-util": "^29.3.1"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@types/jest/node_modules/jest-diff": {
-            "version": "29.3.1",
-            "license": "MIT",
-            "dependencies": {
-                "chalk": "^4.0.0",
-                "diff-sequences": "^29.3.1",
-                "jest-get-type": "^29.2.0",
-                "pretty-format": "^29.3.1"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@types/jest/node_modules/jest-get-type": {
-            "version": "29.2.0",
-            "license": "MIT",
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@types/jest/node_modules/jest-matcher-utils": {
-            "version": "29.3.1",
-            "license": "MIT",
-            "dependencies": {
-                "chalk": "^4.0.0",
-                "jest-diff": "^29.3.1",
-                "jest-get-type": "^29.2.0",
-                "pretty-format": "^29.3.1"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@types/jest/node_modules/jest-message-util": {
-            "version": "29.3.1",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/code-frame": "^7.12.13",
-                "@jest/types": "^29.3.1",
-                "@types/stack-utils": "^2.0.0",
-                "chalk": "^4.0.0",
-                "graceful-fs": "^4.2.9",
-                "micromatch": "^4.0.4",
-                "pretty-format": "^29.3.1",
-                "slash": "^3.0.0",
-                "stack-utils": "^2.0.3"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@types/jest/node_modules/jest-util": {
-            "version": "29.3.1",
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "^29.3.1",
-                "@types/node": "*",
-                "chalk": "^4.0.0",
-                "ci-info": "^3.2.0",
-                "graceful-fs": "^4.2.9",
-                "picomatch": "^2.2.3"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@types/jest/node_modules/pretty-format": {
-            "version": "29.3.1",
-            "license": "MIT",
-            "dependencies": {
-                "@jest/schemas": "^29.0.0",
-                "ansi-styles": "^5.0.0",
-                "react-is": "^18.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@types/jest/node_modules/react-is": {
-            "version": "18.2.0",
-            "license": "MIT"
-        },
         "node_modules/@types/json-schema": {
             "version": "7.0.11",
             "license": "MIT"
@@ -3457,13 +3205,6 @@
                 "@types/prop-types": "*",
                 "@types/scheduler": "*",
                 "csstype": "^3.0.2"
-            }
-        },
-        "node_modules/@types/react-dom": {
-            "version": "17.0.18",
-            "license": "MIT",
-            "dependencies": {
-                "@types/react": "^17"
             }
         },
         "node_modules/@types/react-transition-group": {
@@ -3517,13 +3258,6 @@
         "node_modules/@types/stack-utils": {
             "version": "2.0.1",
             "license": "MIT"
-        },
-        "node_modules/@types/testing-library__jest-dom": {
-            "version": "5.14.5",
-            "license": "MIT",
-            "dependencies": {
-                "@types/jest": "*"
-            }
         },
         "node_modules/@types/trusted-types": {
             "version": "2.0.2",
@@ -4109,13 +3843,6 @@
                 "sprintf-js": "~1.0.2"
             }
         },
-        "node_modules/aria-query": {
-            "version": "5.1.3",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "deep-equal": "^2.0.5"
-            }
-        },
         "node_modules/array-flatten": {
             "version": "1.1.1",
             "license": "MIT"
@@ -4268,16 +3995,6 @@
             },
             "peerDependencies": {
                 "postcss": "^8.1.0"
-            }
-        },
-        "node_modules/available-typed-arrays": {
-            "version": "1.0.5",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/axe-core": {
@@ -5286,10 +5003,6 @@
                 "url": "https://github.com/sponsors/fb55"
             }
         },
-        "node_modules/css.escape": {
-            "version": "1.5.1",
-            "license": "MIT"
-        },
         "node_modules/cssdb": {
             "version": "7.2.0",
             "license": "CC0-1.0",
@@ -5452,30 +5165,6 @@
         "node_modules/dedent": {
             "version": "0.7.0",
             "license": "MIT"
-        },
-        "node_modules/deep-equal": {
-            "version": "2.1.0",
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "es-get-iterator": "^1.1.2",
-                "get-intrinsic": "^1.1.3",
-                "is-arguments": "^1.1.1",
-                "is-date-object": "^1.0.5",
-                "is-regex": "^1.1.4",
-                "isarray": "^2.0.5",
-                "object-is": "^1.1.5",
-                "object-keys": "^1.1.1",
-                "object.assign": "^4.1.4",
-                "regexp.prototype.flags": "^1.4.3",
-                "side-channel": "^1.0.4",
-                "which-boxed-primitive": "^1.0.2",
-                "which-collection": "^1.0.1",
-                "which-typed-array": "^1.1.8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
         },
         "node_modules/deep-is": {
             "version": "0.1.4",
@@ -5655,10 +5344,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/dom-accessibility-api": {
-            "version": "0.5.14",
-            "license": "MIT"
         },
         "node_modules/dom-converter": {
             "version": "0.2.0",
@@ -5888,23 +5573,6 @@
         "node_modules/es-array-method-boxes-properly": {
             "version": "1.0.0",
             "license": "MIT"
-        },
-        "node_modules/es-get-iterator": {
-            "version": "1.1.2",
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "get-intrinsic": "^1.1.0",
-                "has-symbols": "^1.0.1",
-                "is-arguments": "^1.1.0",
-                "is-map": "^2.0.2",
-                "is-set": "^2.0.2",
-                "is-string": "^1.0.5",
-                "isarray": "^2.0.5"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
         },
         "node_modules/es-module-lexer": {
             "version": "0.9.3",
@@ -6877,13 +6545,6 @@
                 }
             }
         },
-        "node_modules/for-each": {
-            "version": "0.3.3",
-            "license": "MIT",
-            "dependencies": {
-                "is-callable": "^1.1.3"
-            }
-        },
         "node_modules/fork-ts-checker-webpack-plugin": {
             "version": "6.5.2",
             "license": "MIT",
@@ -7699,13 +7360,6 @@
                 "node": ">=0.8.19"
             }
         },
-        "node_modules/indent-string": {
-            "version": "4.0.0",
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/inflight": {
             "version": "1.0.6",
             "license": "ISC",
@@ -7746,20 +7400,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 10"
-            }
-        },
-        "node_modules/is-arguments": {
-            "version": "1.1.1",
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "has-tostringtag": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-arrayish": {
@@ -7877,13 +7517,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/is-map": {
-            "version": "2.0.2",
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/is-module": {
             "version": "1.0.0",
             "license": "MIT"
@@ -7974,13 +7607,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/is-set": {
-            "version": "2.0.2",
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/is-shared-array-buffer": {
             "version": "1.0.2",
             "license": "MIT",
@@ -8027,50 +7653,15 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/is-typed-array": {
-            "version": "1.1.10",
-            "license": "MIT",
-            "dependencies": {
-                "available-typed-arrays": "^1.0.5",
-                "call-bind": "^1.0.2",
-                "for-each": "^0.3.3",
-                "gopd": "^1.0.1",
-                "has-tostringtag": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/is-typedarray": {
             "version": "1.0.0",
             "license": "MIT"
-        },
-        "node_modules/is-weakmap": {
-            "version": "2.0.1",
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
         },
         "node_modules/is-weakref": {
             "version": "1.0.2",
             "license": "MIT",
             "dependencies": {
                 "call-bind": "^1.0.2"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-weakset": {
-            "version": "2.0.2",
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "get-intrinsic": "^1.1.1"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -8085,10 +7676,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/isarray": {
-            "version": "2.0.5",
-            "license": "MIT"
         },
         "node_modules/isexe": {
             "version": "2.0.0",
@@ -9236,13 +8823,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/lz-string": {
-            "version": "1.4.4",
-            "license": "WTFPL",
-            "bin": {
-                "lz-string": "bin/bin.js"
-            }
-        },
         "node_modules/magic-string": {
             "version": "0.25.9",
             "license": "MIT",
@@ -9360,13 +8940,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/min-indent": {
-            "version": "1.0.1",
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/mini-css-extract-plugin": {
@@ -9549,20 +9122,6 @@
         "node_modules/object-inspect": {
             "version": "1.12.2",
             "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/object-is": {
-            "version": "1.1.5",
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.1.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -11648,17 +11207,6 @@
                 "node": ">=6.0.0"
             }
         },
-        "node_modules/redent": {
-            "version": "3.0.0",
-            "license": "MIT",
-            "dependencies": {
-                "indent-string": "^4.0.0",
-                "strip-indent": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/regenerate": {
             "version": "1.4.2",
             "license": "MIT"
@@ -12559,16 +12107,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/strip-indent": {
-            "version": "3.0.0",
-            "license": "MIT",
-            "dependencies": {
-                "min-indent": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/strip-json-comments": {
@@ -13684,37 +13222,6 @@
                 "is-number-object": "^1.0.4",
                 "is-string": "^1.0.5",
                 "is-symbol": "^1.0.3"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/which-collection": {
-            "version": "1.0.1",
-            "license": "MIT",
-            "dependencies": {
-                "is-map": "^2.0.1",
-                "is-set": "^2.0.1",
-                "is-weakmap": "^2.0.1",
-                "is-weakset": "^2.0.1"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/which-typed-array": {
-            "version": "1.1.9",
-            "license": "MIT",
-            "dependencies": {
-                "available-typed-arrays": "^1.0.5",
-                "call-bind": "^1.0.2",
-                "for-each": "^0.3.3",
-                "gopd": "^1.0.1",
-                "has-tostringtag": "^1.0.0",
-                "is-typed-array": "^1.1.10"
-            },
-            "engines": {
-                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"

--- a/react-visualizer/package-lock.json
+++ b/react-visualizer/package-lock.json
@@ -8,7 +8,6 @@
             "name": "g-checker-from-itf",
             "version": "0.1.0",
             "dependencies": {
-                "@material-ui/core": "^4.12.3",
                 "@testing-library/jest-dom": "^5.16.1",
                 "@testing-library/react": "^12.1.2",
                 "@testing-library/user-event": "^13.5.0",
@@ -2582,155 +2581,6 @@
             "version": "2.0.4",
             "license": "MIT"
         },
-        "node_modules/@material-ui/core": {
-            "version": "4.12.4",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.4.4",
-                "@material-ui/styles": "^4.11.5",
-                "@material-ui/system": "^4.12.2",
-                "@material-ui/types": "5.1.0",
-                "@material-ui/utils": "^4.11.3",
-                "@types/react-transition-group": "^4.2.0",
-                "clsx": "^1.0.4",
-                "hoist-non-react-statics": "^3.3.2",
-                "popper.js": "1.16.1-lts",
-                "prop-types": "^15.7.2",
-                "react-is": "^16.8.0 || ^17.0.0",
-                "react-transition-group": "^4.4.0"
-            },
-            "engines": {
-                "node": ">=8.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/material-ui"
-            },
-            "peerDependencies": {
-                "@types/react": "^16.8.6 || ^17.0.0",
-                "react": "^16.8.0 || ^17.0.0",
-                "react-dom": "^16.8.0 || ^17.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@material-ui/core/node_modules/react-is": {
-            "version": "17.0.2",
-            "license": "MIT"
-        },
-        "node_modules/@material-ui/styles": {
-            "version": "4.11.5",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.4.4",
-                "@emotion/hash": "^0.8.0",
-                "@material-ui/types": "5.1.0",
-                "@material-ui/utils": "^4.11.3",
-                "clsx": "^1.0.4",
-                "csstype": "^2.5.2",
-                "hoist-non-react-statics": "^3.3.2",
-                "jss": "^10.5.1",
-                "jss-plugin-camel-case": "^10.5.1",
-                "jss-plugin-default-unit": "^10.5.1",
-                "jss-plugin-global": "^10.5.1",
-                "jss-plugin-nested": "^10.5.1",
-                "jss-plugin-props-sort": "^10.5.1",
-                "jss-plugin-rule-value-function": "^10.5.1",
-                "jss-plugin-vendor-prefixer": "^10.5.1",
-                "prop-types": "^15.7.2"
-            },
-            "engines": {
-                "node": ">=8.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/material-ui"
-            },
-            "peerDependencies": {
-                "@types/react": "^16.8.6 || ^17.0.0",
-                "react": "^16.8.0 || ^17.0.0",
-                "react-dom": "^16.8.0 || ^17.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@material-ui/styles/node_modules/@emotion/hash": {
-            "version": "0.8.0",
-            "license": "MIT"
-        },
-        "node_modules/@material-ui/styles/node_modules/csstype": {
-            "version": "2.6.21",
-            "license": "MIT"
-        },
-        "node_modules/@material-ui/system": {
-            "version": "4.12.2",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.4.4",
-                "@material-ui/utils": "^4.11.3",
-                "csstype": "^2.5.2",
-                "prop-types": "^15.7.2"
-            },
-            "engines": {
-                "node": ">=8.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/material-ui"
-            },
-            "peerDependencies": {
-                "@types/react": "^16.8.6 || ^17.0.0",
-                "react": "^16.8.0 || ^17.0.0",
-                "react-dom": "^16.8.0 || ^17.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@material-ui/system/node_modules/csstype": {
-            "version": "2.6.21",
-            "license": "MIT"
-        },
-        "node_modules/@material-ui/types": {
-            "version": "5.1.0",
-            "license": "MIT",
-            "peerDependencies": {
-                "@types/react": "*"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@material-ui/utils": {
-            "version": "4.11.3",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.4.4",
-                "prop-types": "^15.7.2",
-                "react-is": "^16.8.0 || ^17.0.0"
-            },
-            "engines": {
-                "node": ">=8.0.0"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0",
-                "react-dom": "^16.8.0 || ^17.0.0"
-            }
-        },
-        "node_modules/@material-ui/utils/node_modules/react-is": {
-            "version": "17.0.2",
-            "license": "MIT"
-        },
         "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
             "version": "5.1.1-v1",
             "license": "MIT",
@@ -4983,13 +4833,6 @@
                 "wrap-ansi": "^7.0.0"
             }
         },
-        "node_modules/clsx": {
-            "version": "1.2.1",
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/co": {
             "version": "4.6.0",
             "license": "MIT",
@@ -5431,14 +5274,6 @@
             },
             "engines": {
                 "node": ">=8.0.0"
-            }
-        },
-        "node_modules/css-vendor": {
-            "version": "2.0.8",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.8.3",
-                "is-in-browser": "^1.0.2"
             }
         },
         "node_modules/css-what": {
@@ -7770,10 +7605,6 @@
                 "node": ">=10.17.0"
             }
         },
-        "node_modules/hyphenate-style-name": {
-            "version": "1.0.4",
-            "license": "BSD-3-Clause"
-        },
         "node_modules/iconv-lite": {
             "version": "0.4.24",
             "license": "MIT",
@@ -8045,10 +7876,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/is-in-browser": {
-            "version": "1.1.3",
-            "license": "MIT"
         },
         "node_modules/is-map": {
             "version": "2.0.2",
@@ -9237,80 +9064,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/jss": {
-            "version": "10.9.2",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.3.1",
-                "csstype": "^3.0.2",
-                "is-in-browser": "^1.1.3",
-                "tiny-warning": "^1.0.2"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/jss"
-            }
-        },
-        "node_modules/jss-plugin-camel-case": {
-            "version": "10.9.2",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.3.1",
-                "hyphenate-style-name": "^1.0.3",
-                "jss": "10.9.2"
-            }
-        },
-        "node_modules/jss-plugin-default-unit": {
-            "version": "10.9.2",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.3.1",
-                "jss": "10.9.2"
-            }
-        },
-        "node_modules/jss-plugin-global": {
-            "version": "10.9.2",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.3.1",
-                "jss": "10.9.2"
-            }
-        },
-        "node_modules/jss-plugin-nested": {
-            "version": "10.9.2",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.3.1",
-                "jss": "10.9.2",
-                "tiny-warning": "^1.0.2"
-            }
-        },
-        "node_modules/jss-plugin-props-sort": {
-            "version": "10.9.2",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.3.1",
-                "jss": "10.9.2"
-            }
-        },
-        "node_modules/jss-plugin-rule-value-function": {
-            "version": "10.9.2",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.3.1",
-                "jss": "10.9.2",
-                "tiny-warning": "^1.0.2"
-            }
-        },
-        "node_modules/jss-plugin-vendor-prefixer": {
-            "version": "10.9.2",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.3.1",
-                "css-vendor": "^2.0.8",
-                "jss": "10.9.2"
-            }
-        },
         "node_modules/jsx-ast-utils": {
             "version": "3.3.3",
             "license": "MIT",
@@ -10279,10 +10032,6 @@
             "engines": {
                 "node": ">=4"
             }
-        },
-        "node_modules/popper.js": {
-            "version": "1.16.1-lts",
-            "license": "MIT"
         },
         "node_modules/postcss": {
             "version": "8.4.20",
@@ -13250,10 +12999,6 @@
         },
         "node_modules/thunky": {
             "version": "1.1.0",
-            "license": "MIT"
-        },
-        "node_modules/tiny-warning": {
-            "version": "1.0.3",
             "license": "MIT"
         },
         "node_modules/tmpl": {

--- a/react-visualizer/package.json
+++ b/react-visualizer/package.json
@@ -41,6 +41,6 @@
     "devDependencies": {
         "gh-pages": "^6.1.1",
         "prettier": "^3.2.5",
-        "typescript": "^5.4.4"
+        "typescript": "^4.6.3"
     }
 }

--- a/react-visualizer/package.json
+++ b/react-visualizer/package.json
@@ -4,14 +4,14 @@
     "private": true,
     "homepage": "https://oshamashama.github.io/g-checker-for-itf/",
     "dependencies": {
-        "bootstrap": "^5.1.3",
-        "react": "^17.0.2",
-        "react-bootstrap": "^2.1.2",
-        "react-dom": "^17.0.2",
-        "react-scripts": "5.0.0",
-        "react-select": "^5.2.2",
-        "react-table": "^7.7.0",
-        "web-vitals": "^2.1.4"
+        "bootstrap": "^5.3.3",
+        "react": "^18.2.0",
+        "react-bootstrap": "^2.10.2",
+        "react-dom": "^18.2.0",
+        "react-scripts": "5.0.1",
+        "react-select": "^5.8.0",
+        "react-table": "^7.8.0",
+        "web-vitals": "^3.5.2"
     },
     "scripts": {
         "start": "react-scripts start",
@@ -39,8 +39,8 @@
         ]
     },
     "devDependencies": {
-        "gh-pages": "^3.2.3",
-        "prettier": "^2.6.2",
-        "typescript": "^4.6.3"
+        "gh-pages": "^6.1.1",
+        "prettier": "^3.2.5",
+        "typescript": "^5.4.4"
     }
 }

--- a/react-visualizer/package.json
+++ b/react-visualizer/package.json
@@ -4,9 +4,6 @@
     "private": true,
     "homepage": "https://oshamashama.github.io/g-checker-for-itf/",
     "dependencies": {
-        "@testing-library/jest-dom": "^5.16.1",
-        "@testing-library/react": "^12.1.2",
-        "@testing-library/user-event": "^13.5.0",
         "bootstrap": "^5.1.3",
         "react": "^17.0.2",
         "react-bootstrap": "^2.1.2",

--- a/react-visualizer/package.json
+++ b/react-visualizer/package.json
@@ -4,7 +4,6 @@
     "private": true,
     "homepage": "https://oshamashama.github.io/g-checker-for-itf/",
     "dependencies": {
-        "@material-ui/core": "^4.12.3",
         "@testing-library/jest-dom": "^5.16.1",
         "@testing-library/react": "^12.1.2",
         "@testing-library/user-event": "^13.5.0",

--- a/react-visualizer/src/setupTests.js
+++ b/react-visualizer/src/setupTests.js
@@ -2,4 +2,4 @@
 // allows you to do things like:
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
-import "@testing-library/jest-dom";
+// import "@testing-library/jest-dom";


### PR DESCRIPTION
## 何を/なぜしたのか
- Reactをv18に
    - 関連するパッケージを[`ncu`](https://www.npmjs.com/package/npm-check-updates)でアップデート
    - ただし`typescript@5.4.4`は`react-scripts@5.0.1`と衝突を起こすため`typescript@4.6.3`で固定
- 衝突を最小限にするため、未使用と思われるパッケージの削除
  -  `@material-ui/core`
  - `@testing-library/*`
- 上記に伴い`react-visualizer/src/setupTests.js` のimportを無効化
- バージョンアップに伴いアプリケーションが壊れていないことを確認するため、PR時にビルドが完了することを確かめるCIの整備
  - ついでに各workflowの各バージョンを最新にする
    - Node.js 16 -> 20
- `npx update-browserslist-db@latest`
  - 理由: https://github.com/oshamashama/g-checker-for-itf/actions/runs/8597743033/job/23557059562#step:6:10

## 実行結果
- https://github.com/BonyChops/g-checker-for-itf/pull/4
- Actions
    - [PR時](https://github.com/BonyChops/g-checker-for-itf/actions/runs/8602751606)
    - [Merge時](https://github.com/BonyChops/g-checker-for-itf/actions/runs/8602762281)
- https://bonychops.github.io/g-checker-for-itf/