### PR TITLE
coinsにおける線形代数と微積の単位変換を追加

### DIFF
--- a/react-visualizer/src/reqJson/coins21.json
+++ b/react-visualizer/src/reqJson/coins21.json
@@ -84,7 +84,7 @@
                                         "min_certificated_credit_num": 2,
                                         "leaf": {
                                             "regexp_number": "",
-                                            "regexp_name": "^線形代数A$"
+                                            "regexp_name": "^線形代数[A12]$"
                                         }
                                     },
                                     "線形代数Ｂ": {
@@ -100,7 +100,7 @@
                                         "min_certificated_credit_num": 2,
                                         "leaf": {
                                             "regexp_number": "",
-                                            "regexp_name": "^微分積分A$"
+                                            "regexp_name": "^微分積分[A12]$"
                                         }
                                     },
                                     "微分積分Ｂ": {

--- a/react-visualizer/src/reqJson/coins23-24.json
+++ b/react-visualizer/src/reqJson/coins23-24.json
@@ -84,7 +84,7 @@
                                         "min_certificated_credit_num": 2,
                                         "leaf": {
                                             "regexp_number": "",
-                                            "regexp_name": "^線形代数A$"
+                                            "regexp_name": "^線形代数[A12]$"
                                         }
                                     },
                                     "線形代数Ｂ": {
@@ -100,7 +100,7 @@
                                         "min_certificated_credit_num": 2,
                                         "leaf": {
                                             "regexp_number": "",
-                                            "regexp_name": "^微分積分A$"
+                                            "regexp_name": "^微分積分[A12]$"
                                         }
                                     },
                                     "微分積分Ｂ": {


### PR DESCRIPTION
2021年度以降に入学して，総合学域群経由でcoinsに来た人は線形代数A，微分積分Aがそれぞれ理工学群開設の線形代数1/2，微分積分1/2の習得をもってこれらの単位に変換できるとされています（2021年度coins入学の場合，[履修細則](https://www.tsukuba.ac.jp/education/ug-courses-directory/2021/pdf/5-2.pdf)のp.242下部に注15として記載があります）．現状これに対応する単位変換が存在しないように見えるので，これを追加します．
![image](https://github.com/oshamashama/g-checker-for-itf/assets/39644970/21dc16ef-7458-43cb-93e6-2f571b9e2795)
